### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/ami.yml
+++ b/tasks/ami.yml
@@ -22,7 +22,8 @@
       }}
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: selected AMI <b>{{ _aws_ec2_ami.image_id }}</b>
   when: notifier_role is defined

--- a/tasks/instance.yml
+++ b/tasks/instance.yml
@@ -98,7 +98,8 @@
     _aws_ec2_i["windows_domain_join"]
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       launched <b>{{ _aws_ec2_i["description"] }} instance</b>

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,8 @@
          if aws_ec2_target_environment is defined else [""] }}
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-ec2</b> on
@@ -63,7 +64,8 @@
     loop_var: _aws_ec2_i
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-ec2</b> on


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.